### PR TITLE
Allow disabling automatic SSE retry

### DIFF
--- a/src/typedEventSource.test.ts
+++ b/src/typedEventSource.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { typedEventSource } from "./typedEventSource";
+
+// Minimal fake EventSource implementation for testing
+type EventHandler = ((ev: Event) => void) | null;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  onopen: EventHandler = null;
+  onerror: EventHandler = null;
+  constructor(public url: string, public opts?: EventSourceInit) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+}
+
+describe("typedEventSource retry option", () => {
+  it("does not reconnect when retry is null", () => {
+    vi.useFakeTimers();
+
+    const sse = typedEventSource(
+      "http://example.com",
+      { retry: null },
+      FakeEventSource as unknown as { new (url: string, init?: EventSourceInit): EventSource }
+    );
+
+    // Trigger an error on the first instance
+    const first = FakeEventSource.instances[0]!;
+    first.onerror?.(new Event("error"));
+
+    // Advance timers to flush potential reconnects
+    vi.runAllTimers();
+
+    // No new instances should be created
+    expect(FakeEventSource.instances.length).toBe(1);
+
+    sse.close();
+    vi.useRealTimers();
+  });
+});

--- a/src/typedEventSource.ts
+++ b/src/typedEventSource.ts
@@ -34,7 +34,9 @@ export function typedEventSource(
   let es: EventSource | null = null;
   let closed = false;
   let attempt = 0;
-  const retryCfg = opts.retry ?? { base: 500, max: 30_000 };
+  // Use defaults only when retry is undefined; allow null to disable retries
+  const retryCfg =
+    opts.retry === undefined ? { base: 500, max: 30_000 } : opts.retry;
   const listeners = new Map<string, Set<(e: MessageEvent) => void>>();
 
   const addRaw = (type: string, fn: (e: MessageEvent) => void) => {


### PR DESCRIPTION
## Summary
- allow `retry: null` to disable reconnection
- add regression test to ensure no reconnect when retries are disabled

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

