### PR TITLE
feat: add typed event map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Use the standard `EventSource` and enhance it with type-safe event listeners usi
 ```ts
 import { addTypedDataEventListener } from "typed-sse";
 
-interface ConnectionData {
-  connection_id: string;
+interface Events {
+  connected: { connection_id: string };
 }
 
 const es = new EventSource("/api/events/stream");
 
-const myEvent = addTypedDataEventListener<ConnectionData>(
+const connected = addTypedDataEventListener<Events>(
   es,
   "connected",
   (data) => {
@@ -45,7 +45,7 @@ const myEvent = addTypedDataEventListener<ConnectionData>(
   }
 );
 
-myEvent.stopListening();
+connected.stopListening();
 es.close();
 ```
 
@@ -65,24 +65,29 @@ interface MessageEventPayload {
   /* ... */
 }
 
-const tes = typedEventSource("/api/events/stream", {
+interface Events {
+  custom: ConnectionData;
+  message: MessageEventPayload;
+}
+
+const tes = typedEventSource<Events>("/api/events/stream", {
   withCredentials: true,
   retry: { base: 500, max: 30000 },
 });
 
-const customEvent = tes.on<ConnectionData>("custom", (data) => {
+const customEvent = tes.on("custom", (data) => {
   console.log("Received 'custom' event with parsed and typed data:", data);
   console.log(
     `You can directly access typed payload properties: data.connection_id: ${data.custom_data_id} , custom_data_number : ${data.custom_data_number}, etc ... `
   );
 });
 
-const messageEvent = tes.on<MessageEventPayload>("message", (data) => {
+const messageEvent = tes.on("message", (data) => {
   // ...
 });
 
 // cleanup
-connectedEvent.stopListening();
+customEvent.stopListening();
 messageEvent.stopListening();
 tes.close();
 ```

--- a/src/addTypedDataEventListener.ts
+++ b/src/addTypedDataEventListener.ts
@@ -1,7 +1,10 @@
 import { parseEvent } from "./types";
-import type { TypedHandler } from "./types";
+import type { TypedHandler, TypedEventMap } from "./types";
 
-export function addTypedDataEventListener<T>(
+export function addTypedDataEventListener<
+  Events extends TypedEventMap,
+  K extends keyof Events
+>(
   /**
    * Adds a typed event listener to an EventSource instance.
    * The handler receives parsed JSON data of type T.
@@ -12,14 +15,16 @@ export function addTypedDataEventListener<T>(
    * @param handler - The callback to handle parsed data.
    */
   es: EventSource,
-  type: string,
-  handler: TypedHandler<T>
+  type: K,
+  handler: TypedHandler<Events[K]>
 ): { stopListening: () => void } {
   const wrapped = (event: Event) => {
-    const data = parseEvent<T>(event as MessageEvent);
+    const data = parseEvent<Events[K]>(event as MessageEvent);
     if (data != null) handler(data);
   };
-  es.addEventListener(type, wrapped);
+  es.addEventListener(type as string, wrapped);
 
-  return { stopListening: () => es.removeEventListener(type, wrapped) };
+  return {
+    stopListening: () => es.removeEventListener(type as string, wrapped),
+  };
 }

--- a/src/typedEventSource.ts
+++ b/src/typedEventSource.ts
@@ -3,6 +3,7 @@ import {
   type EventSourceCtor,
   type CreateOptions,
   type TypedHandler,
+  type TypedEventMap,
 } from "./types";
 
 function getDefaultCtor(): EventSourceCtor | undefined {
@@ -10,7 +11,9 @@ function getDefaultCtor(): EventSourceCtor | undefined {
   return (globalThis as any).EventSource as EventSourceCtor | undefined;
 }
 
-export function typedEventSource(
+export function typedEventSource<
+  Events extends TypedEventMap = TypedEventMap
+>(
   url: string,
   opts: CreateOptions = {},
   ES: EventSourceCtor | undefined = getDefaultCtor()
@@ -82,17 +85,17 @@ export function typedEventSource(
   connect();
 
   return {
-    on<T>(
-      type: string,
-      handler: TypedHandler<T>
+    on<K extends keyof Events>(
+      type: K,
+      handler: TypedHandler<Events[K]>
     ): { stopListening: () => void } {
       const wrapped = (ev: MessageEvent) => {
-        const data = parseEvent<T>(ev);
+        const data = parseEvent<Events[K]>(ev);
         if (data != null) handler(data);
       };
-      addRaw(type, wrapped);
+      addRaw(type as string, wrapped);
       return {
-        stopListening: () => removeRaw(type, wrapped),
+        stopListening: () => removeRaw(type as string, wrapped),
       };
     },
     close() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,17 @@
 export type TypedHandler<T> = (data: T) => void;
 
 /**
+ * Mapping between SSE event names and their expected payload types.
+ *
+ * @example
+ * interface Events {
+ *   connected: { id: string };
+ *   message: { text: string };
+ * }
+ */
+export type TypedEventMap = Record<string, unknown>;
+
+/**
  * Options for creating a typed EventSource, including retry configuration.
  */
 export interface CreateOptions extends EventSourceInit {


### PR DESCRIPTION
## Summary
- add `TypedEventMap` for mapping event names to payload types
- support typed event names in `addTypedDataEventListener` and `typedEventSource`
- document typed event map usage in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: No test files found)*
- `npm run build`


------
