### PR TITLE
refactor: convert typedEventSource to class

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 You can use `typed-sse` in two ways:
 
 1. With the classic `EventSource` API for minimal changes to your existing code.
-2. With the custom `typedEventSource` for a more streamlined and type-safe experience.
+2. With the custom `TypedEventSource` class for a more streamlined and type-safe experience.
 
 ### Method 1: Classic EventSource
 
@@ -46,12 +46,12 @@ connected.stopListening();
 es.close();
 ```
 
-### Method 2: typedEventSource
+### Method 2: TypedEventSource
 
-- Use the `typedEventSource` function for a more streamlined and type-safe experience. This approach provides a convenient API for subscribing to events with automatic type checking.
+- Use the `TypedEventSource` class for a more streamlined and type-safe experience. Instantiate it to subscribe to events with automatic type checking.
 
 ```ts
-import { typedEventSource } from "typed-sse";
+import { TypedEventSource } from "typed-sse";
 
 interface ConnectionData {
   custom_data_id: string;
@@ -67,7 +67,7 @@ interface Events {
   message: MessageEventPayload;
 }
 
-const tes = typedEventSource<Events>("/api/events/stream", {
+const tes = new TypedEventSource<Events>("/api/events/stream", {
   withCredentials: true,
   retry: { base: 500, max: 30000 },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-sse",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Typed helpers for Server-Sent Events (EventSource) with JSON parsing and optional reconnect.",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@
 
 export * from "./types";
 export * from "./addTypedDataEventListener";
-export * from "./typedEventSource";
+export { TypedEventSource } from "./typedEventSource";

--- a/src/typedEventSource.test.ts
+++ b/src/typedEventSource.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { typedEventSource } from "./typedEventSource";
+import { TypedEventSource } from "./typedEventSource";
+import type { EventSourceCtor } from "./types";
 
 // Minimal fake EventSource implementation for testing
 type EventHandler = ((ev: Event) => void) | null;
@@ -16,16 +17,14 @@ class FakeEventSource {
   close() {}
 }
 
-describe("typedEventSource retry option", () => {
+describe("TypedEventSource retry option", () => {
   it("does not reconnect when retry is null", () => {
     vi.useFakeTimers();
 
-    const sse = typedEventSource(
+    const sse = new TypedEventSource(
       "http://example.com",
       { retry: null },
-      FakeEventSource as unknown as {
-        new (url: string, init?: EventSourceInit): EventSource;
-      }
+      FakeEventSource as unknown as EventSourceCtor
     );
 
     // Trigger an error on the first instance

--- a/src/typedEventSource.ts
+++ b/src/typedEventSource.ts
@@ -11,100 +11,100 @@ function getDefaultCtor(): EventSourceCtor | undefined {
   return globalThis.EventSource as EventSourceCtor | undefined;
 }
 
-export function typedEventSource<Events extends TypedEventMap = TypedEventMap>(
-  url: string,
-  opts: CreateOptions = {},
-  ES: EventSourceCtor | undefined = getDefaultCtor()
-) {
-  /**
-   * Creates a typed EventSource with auto-reconnect and typed event listeners.
-   * Supports environments without native EventSource by allowing a custom constructor.
-   *
-   * @param url - The SSE endpoint URL.
-   * @param opts - Options for retry and credentials.
-   * @param ES - Optional EventSource constructor (for polyfills).
-   * @throws If EventSource is not available in the environment.
-   */
-  if (!ES) {
-    throw new Error(
-      "EventSource is not available in this environment. " +
-        "Provide a constructor (e.g., from the 'eventsource' polyfill) as the 3rd argument."
-    );
+export class TypedEventSource<
+  Events extends TypedEventMap = TypedEventMap,
+> {
+  private es: EventSource | null = null;
+  private closed = false;
+  private attempt = 0;
+  private readonly retryCfg: { base?: number; max?: number } | null;
+  private readonly listeners = new Map<string, Set<(e: MessageEvent) => void>>();
+
+  constructor(
+    private url: string,
+    private opts: CreateOptions = {},
+    ES: EventSourceCtor | undefined = getDefaultCtor(),
+  ) {
+    if (!ES) {
+      throw new Error(
+        "EventSource is not available in this environment. " +
+          "Provide a constructor (e.g., from the 'eventsource' polyfill) as the 3rd argument.",
+      );
+    }
+
+    this.ES = ES;
+    this.retryCfg =
+      opts.retry === undefined ? { base: 500, max: 30_000 } : opts.retry;
+
+    this.connect();
   }
 
-  let es: EventSource | null = null;
-  let closed = false;
-  let attempt = 0;
-  // Use defaults only when retry is undefined; allow null to disable retries
-  const retryCfg =
-    opts.retry === undefined ? { base: 500, max: 30_000 } : opts.retry;
-  const listeners = new Map<string, Set<(e: MessageEvent) => void>>();
+  private ES: EventSourceCtor;
 
-  const addRaw = (type: string, fn: (e: MessageEvent) => void) => {
-    if (!listeners.has(type)) listeners.set(type, new Set());
-    listeners.get(type)!.add(fn);
-    es?.addEventListener(type, fn as EventListener);
-  };
+  private addRaw(type: string, fn: (e: MessageEvent) => void) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(fn);
+    this.es?.addEventListener(type, fn as EventListener);
+  }
 
-  const removeRaw = (type: string, fn: (e: MessageEvent) => void) => {
-    listeners.get(type)?.delete(fn);
-    es?.removeEventListener(type, fn as EventListener);
-  };
+  private removeRaw(type: string, fn: (e: MessageEvent) => void) {
+    this.listeners.get(type)?.delete(fn);
+    this.es?.removeEventListener(type, fn as EventListener);
+  }
 
-  const attachAll = () => {
-    for (const [type, set] of listeners.entries()) {
-      for (const fn of set) es?.addEventListener(type, fn as EventListener);
+  private attachAll() {
+    for (const [type, set] of this.listeners.entries()) {
+      for (const fn of set) this.es?.addEventListener(type, fn as EventListener);
     }
-  };
+  }
 
-  const connect = () => {
-    if (closed) return;
-    es = new ES!(url, opts); // <- plus d’erreur de signature
+  private connect() {
+    if (this.closed) return;
+    this.es = new this.ES(this.url, this.opts);
 
-    attempt = 0;
+    this.attempt = 0;
 
-    es.onopen = () => {
-      attempt = 0;
+    this.es.onopen = () => {
+      this.attempt = 0;
     };
 
-    es.onerror = () => {
-      es?.close();
-      es = null;
-      if (closed || !retryCfg) return;
-      attempt++;
+    this.es.onerror = () => {
+      this.es?.close();
+      this.es = null;
+      if (this.closed || !this.retryCfg) return;
+      this.attempt++;
       const backoff = Math.min(
-        (retryCfg.base ?? 500) * Math.pow(2, attempt - 1),
-        retryCfg.max ?? 30_000
+        (this.retryCfg.base ?? 500) * Math.pow(2, this.attempt - 1),
+        this.retryCfg.max ?? 30_000,
       );
-      setTimeout(connect, backoff);
+      setTimeout(() => this.connect(), backoff);
     };
 
-    attachAll();
-  };
+    this.attachAll();
+  }
 
-  connect();
+  on<K extends keyof Events>(
+    type: K,
+    handler: TypedHandler<Events[K]>,
+  ): { stopListening: () => void } {
+    const wrapped = (ev: MessageEvent) => {
+      const data = parseEvent<Events[K]>(ev);
+      if (data != null) handler(data);
+    };
+    this.addRaw(type as string, wrapped);
+    return {
+      stopListening: () => this.removeRaw(type as string, wrapped),
+    };
+  }
 
-  return {
-    on<K extends keyof Events>(
-      type: K,
-      handler: TypedHandler<Events[K]>
-    ): { stopListening: () => void } {
-      const wrapped = (ev: MessageEvent) => {
-        const data = parseEvent<Events[K]>(ev);
-        if (data != null) handler(data);
-      };
-      addRaw(type as string, wrapped);
-      return {
-        stopListening: () => removeRaw(type as string, wrapped),
-      };
-    },
-    close() {
-      closed = true;
-      es?.close();
-      es = null;
-    },
-    get current(): EventSource | null {
-      return es;
-    },
-  };
+  close() {
+    this.closed = true;
+    this.es?.close();
+    this.es = null;
+  }
+
+  get current(): EventSource | null {
+    return this.es;
+  }
 }
+


### PR DESCRIPTION
## Summary
- convert helper function into `TypedEventSource` class for typed SSE connections
- document and test the new class API

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


